### PR TITLE
[FIX] Remove project_categ from dependencies

### DIFF
--- a/business_requirement_deliverable_categ/__openerp__.py
+++ b/business_requirement_deliverable_categ/__openerp__.py
@@ -10,7 +10,6 @@
     "author": "Elico Corp, Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "depends": [
-        "project_categ",
         "business_requirement_deliverable"
     ],
     "data": [


### PR DESCRIPTION
Remove module project_categ from dependencies.
The OCA module project_categ is not yet ported to V9. Moreover the project.category model was removed from the standard V9, in favor of model project.tags.

With this PR I propose to not make use of project_categ at all.
Anyway still we should have an open discussion on how to handle the missing parent-child relation between project.tags.
